### PR TITLE
Improve facts management

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class augeas (
   $lens_dir     = $augeas::params::lens_dir,
   $purge        = true,
 ) inherits augeas::params {
-  if versioncmp($::puppetversion, '4.0.0') >= 0 {
+  if versioncmp($facts['puppetversion'], '4.0.0') >= 0 {
     contain 'augeas::files'
   } else {
     contain 'augeas::packages'

--- a/manifests/lens.pp
+++ b/manifests/lens.pp
@@ -58,7 +58,7 @@ define augeas::lens (
     mode => '0644',
   }
 
-  if (!$stock_since or versioncmp(String($::augeasversion), $stock_since) < 0) {
+  if (!$stock_since or versioncmp(String($facts['augeasversion']), $stock_since) < 0) {
     assert_type(Pattern[/^\/.*/], $augeas::lens_dir)
 
     $lens_name = "${name}.aug"
@@ -77,7 +77,7 @@ define augeas::lens (
     exec { "Typecheck lens ${name}":
       command     => "augparse -I . ${lens_name} || (rm -f ${lens_name} && exit 1)",
       cwd         => $augeas::lens_dir,
-      path        => "/opt/puppetlabs/puppet/bin:${::path}",
+      path        => "/opt/puppetlabs/puppet/bin:${facts['path']}",
       refreshonly => true,
       subscribe   => File[$lens_dest],
     }
@@ -95,7 +95,7 @@ define augeas::lens (
       exec { "Test lens ${name}":
         command     => "augparse -I . ${test_name} || (rm -f ${lens_name} && rm -f ${test_name}.aug && exit 1)",
         cwd         => $augeas::lens_dir,
-        path        => "/opt/puppetlabs/puppet/bin:${::path}",
+        path        => "/opt/puppetlabs/puppet/bin:${facts['path']}",
         refreshonly => true,
         subscribe   => File[$lens_dest, $test_dest],
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,9 +3,9 @@
 # Default parameters for the Augeas module
 #
 class augeas::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     'RedHat': {
-      $ruby_pkg = $::operatingsystem ? {
+      $ruby_pkg = $facts['os']['name'] ? {
         # Amazon Linux AMI (2014.09 and 2015.03) uses ruby 2.0
         'Amazon' => 'ruby20-augeas',
         default => 'ruby-augeas'
@@ -15,7 +15,7 @@ class augeas::params {
 
     'Suse': {
       # RPM Sources: https://build.opensuse.org/project/show/systemsmanagement:puppet
-      if versioncmp($::rubyversion, '2.1.2') >= 0 {
+      if versioncmp($facts['ruby']['version'], '2.1.2') >= 0 {
         # SLES 12 / openSUSE
         $ruby_pkg = 'ruby2.1-rubygem-ruby-augeas'
       } else {
@@ -26,10 +26,10 @@ class augeas::params {
     }
 
     'Debian': {
-      if versioncmp($::rubyversion, '2.1.0') >= 0 {
+      if versioncmp($facts['ruby']['version'], '2.1.0') >= 0 {
         $ruby_pkg = 'ruby-augeas'
       }
-      elsif versioncmp($::rubyversion, '1.9.1') >= 0 {
+      elsif versioncmp($facts['ruby']['version'], '1.9.1') >= 0 {
         $ruby_pkg = 'libaugeas-ruby1.9.1'
       } else {
         $ruby_pkg = 'libaugeas-ruby1.8'
@@ -50,9 +50,9 @@ class augeas::params {
     default:  { fail("Unsupported OS family: ${facts['os']['family']}") }
   }
 
-  if (versioncmp($::puppetversion, '4.0.0') >= 0) and ($::rubysitedir =~ /\/opt\/puppetlabs\/puppet/) {
+  if (versioncmp($facts['puppetversion'], '4.0.0') >= 0) and ($facts['ruby']['sitedir'] =~ /\/opt\/puppetlabs\/puppet/) {
     $lens_dir = '/opt/puppetlabs/puppet/share/augeas/lenses'
-  } elsif (defined('$is_pe') and str2bool("${::is_pe}")) { # lint:ignore:only_variable_string
+  } elsif ('$is_pe' in $facts and str2bool("${facts['is_pe']}")) { # lint:ignore:only_variable_string
     # puppet enterpise has a different lens location
     $lens_dir = '/opt/puppet/share/augeas/lenses'
   } else {


### PR DESCRIPTION
- Replace legacy facts with their equivalent syntax;
- Avoid usage of top-scope variables to access facts.

This is intended to fix the module when disabling legacy facts in puppet
with `puppet config set include_legacy_facts false`.
