### PR TITLE
Drop support for EOL operating systems

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,18 +21,12 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
-        "7",
-        "10",
         "11"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "10.04",
-        "12.04",
-        "14.04",
         "20.04",
         "22.04"
       ]
@@ -40,8 +34,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
-        "6",
         "9"
       ]
     },
@@ -58,8 +50,6 @@
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "11",
-        "12",
         "13",
         "14"
       ]


### PR DESCRIPTION
* Debian 6, 7, 10
* Ubuntu 10.04, 12.04, 14.04
* RedHat 5, 6
* FreeBSD 11, 12
