### PR TITLE
Add support for Debian 12, Ubuntu 24.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,14 +21,16 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "11"
+        "11",
+        "12"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "20.04",
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     },
     {


### PR DESCRIPTION
Before doing a release, it make sense to add support for these latest versions of the supported operating systems.

Resolves:
- https://github.com/voxpupuli/puppet-augeas/issues/95